### PR TITLE
Update setting itemtypes for articles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,6 +84,7 @@ defaults:
     path: _posts
   values:
     layout: post
+    itemtype: NewsArticle
     author:
       givenName: Chris
       familyName: Zuber
@@ -105,6 +106,7 @@ defaults:
     path: _drafts
   values:
     layout: post
+    itemtype: NewsArticle
     author:
       givenName: Chris
       familyName: Zuber

--- a/_includes/article.html
+++ b/_includes/article.html
@@ -1,7 +1,7 @@
 <span hidden="">
 	{% include breadcrumb-nav.html category=page.category post=page %}
 </span>
-<article itemtype="http://schema.org/BlogPosting" role="article" class="font-article" itemscope="">
+<article itemtype="http://schema.org/{{ include.itemtype | default: 'Article' }}" role="article" class="font-article" itemscope="">
 	{% if page.publisher %}
 		<div itemprop="publisher" itemtype="https://schema.org/{{ include.publisher[@type] | default: 'Organization' }}" itemscope="" hidden="">
 			<meta itemprop="name" content="{{ include.publisher.name }}" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@ pinned-posts: 5
 	{% if site.google-analytics %}data-google-analytics="{{ site.google-analytics }}"{% endif %}
 	{% if page.ads %}data-ad-sense-id="{{ site.ad-sense }}"{% endif %}
 	{% if page.pageLevelAds %}data-page-level-ads="{{ page.pageLevelAds }}"{% endif %}
-	itemtype="{{ page.itemtype | default: layout.itemtype }}"
+	itemtype="{{ layout.itemtype }}"
 	prefix="og: http://ogp.me/ns#"
 	itemscope=""
 >

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,7 @@ itemtype: 'https://schema.org/WebPage'
 	{% if site.google-analytics %}data-google-analytics="{{ site.google-analytics }}"{% endif %}
 	{% if page.ads %}data-ad-sense-id="{{ site.ad-sense }}"{% endif %}
 	{% if page.pageLevelAds %}data-page-level-ads="{{ page.pageLevelAds }}"{% endif %}
-	itemtype="{{ page.itemtype | default: layout.itemtype }}"
+	itemtype="{{ layout.itemtype }}"
 	prefix="og: http://ogp.me/ns#"
 	itemscope=""
 >
@@ -24,7 +24,7 @@ itemtype: 'https://schema.org/WebPage'
 		{% include header.html %}
 		{% include nav.html %}
 		<main id="main" class="card shadow">
-			{% include article.html publisher=page.publisher author=page.author %}
+			{% include article.html publisher=page.publisher author=page.author itemtype=page.itemtype %}
 		</main>
 		{% include sidebar.html recent-posts=5 %}
 		{% include footer.html %}

--- a/_layouts/wide.html
+++ b/_layouts/wide.html
@@ -15,7 +15,7 @@ itemtype: 'https://schema.org/WebPage'
 	{% if site.google-analytics %}data-google-analytics="{{ site.google-analytics }}"{% endif %}
 	{% if page.ads %}data-ad-sense-id="{{ site.ad-sense }}"{% endif %}
 	{% if page.pageLevelAds %}data-page-level-ads="{{ page.pageLevelAds }}"{% endif %}
-	itemtype="{{ page.itemtype | default: layout.itemtype }}"
+	itemtype="{{ layout.itemtype }}"
 	prefix="og: http://ogp.me/ns#"
 	itemscope=""
 >


### PR DESCRIPTION
Previously everything was blog. Now, defaults to 'Article', but allows setting via `page.itemtype`