### PR TITLE
Update mobile grid layout

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: shgysk8zer0
+# github: shgysk8zer0
 liberapay: shgysk8zer0

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,18 +1,11 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-<<<<<<< HEAD
-labels: ''
-assignees: ''
-
+title: Report a bug
+labels: bug
+assignees: shgysk8zer0
 ---
 
-=======
-labels: 'bug'
-assignees: 'shgysk8zer0'
----
->>>>>>> patch/rebase
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,18 +1,11 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-<<<<<<< HEAD
-labels: ''
-assignees: ''
-
+title: Request a feature
+labels: enhancement
+assignees: shgysk8zer0
 ---
 
-=======
-labels: 'enhancement'
-assignees: 'shgysk8zer0'
----
->>>>>>> patch/rebase
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/_data/app.yml
+++ b/_data/app.yml
@@ -1,6 +1,6 @@
 name: Kern River Courier
 shortName: Courier
-version: 1.0.4-b1
+version: 1.0.5
 display: standalone
 description: "News for the Kern River Valley"
 icons-file: /img/icons.svg

--- a/css/index.css
+++ b/css/index.css
@@ -19,6 +19,7 @@
 		grid-template-columns: 100%;
 	}
 }
+
 input[hidden] + label[for].btn-toggle {
 	background-color: var(--button-disabled-background);
 	margin: 0.3rem;

--- a/css/index.css
+++ b/css/index.css
@@ -14,6 +14,11 @@
 @import url("./vars.css");
 @import url("./layout.css");
 
+@media (max-width: 800px) {
+	:root:not([data-layout]) > body.grid, :root[data-layout="default"] > body.grid, body.grid {
+		grid-template-columns: 100%;
+	}
+}
 input[hidden] + label[for].btn-toggle {
 	background-color: var(--button-disabled-background);
 	margin: 0.3rem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "news-kernvalley-us",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "news-kernvalley-us",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "private": true,
   "description": "A template repository for Jekyll sites, including skeleton JS, CSS, SVGs, fonts, etc.",
   "config": {


### PR DESCRIPTION
Set columns to `100%` instead of `auto`. Resolves #13

Also adds missing issue templates, funding/donations config, & bumps version to 1.0.5