### PR TITLE
Import Super Linter config from template repo

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -14,21 +14,21 @@ appearance, race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
+- The use of sexualized language or imagery and unwelcome sexual attention or
  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
  professional setting
 
 ## Our Responsibilities
@@ -68,9 +68,9 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq)

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-# github: shgysk8zer0
+github: shgysk8zer0
 liberapay: shgysk8zer0

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: Report a bug
 labels: bug
-assignees: shgysk8zer0
+assignees: ''
 ---
 
 **Describe the bug**
@@ -23,15 +23,15 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+- OS: [e.g. iOS]
+- Browser: [e.g. chrome, safari]
+- Version: [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser: [e.g. stock browser, safari]
+- Version: [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: Request a feature
 labels: enhancement
-assignees: shgysk8zer0
+assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
-## Description and issue
+# Description and issue
 
-### List of significant changes made
+> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`
+
+## List of significant changes made
 -  
 -  
-

--- a/.github/linters/.ansible-lint.yml
+++ b/.github/linters/.ansible-lint.yml
@@ -1,0 +1,51 @@
+##########################
+##########################
+## Ansible Linter rules ##
+##########################
+##########################
+
+#############################
+# Exclude paths from linter #
+#############################
+#exclude_paths:
+
+########################
+# Make output parsable #
+########################
+parseable: true
+
+#######################
+# Set output to quiet #
+#######################
+quiet: true
+
+#####################
+# Path to rules dir #
+#####################
+#rulesdir:
+
+################
+# Tags to skip #
+################
+skip_list:
+  - '602' # Allow compare to empty string
+  - '204' # Allow string length greater that 160 chars
+  - '301' # False positives for running command shells
+  - '303' # Allow git commands for push add, etc...
+  - '305' # Allow use of shell when you want
+  - '503' # Allow step to run like handler
+
+##################
+# Tags to follow #
+##################
+#tags:
+
+#############
+# Use rules #
+#############
+use_default_rules: true
+
+#################
+# Set verbosity #
+#################
+verbosity: 1

--- a/.github/linters/.coffee-lint.json
+++ b/.github/linters/.coffee-lint.json
@@ -1,0 +1,135 @@
+{
+  "arrow_spacing": {
+    "level": "ignore"
+  },
+  "braces_spacing": {
+    "level": "ignore",
+    "spaces": 0,
+    "empty_object_spaces": 0
+  },
+  "camel_case_classes": {
+    "level": "error"
+  },
+  "coffeescript_error": {
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "level": "ignore",
+    "spacing": {
+      "left": 0,
+      "right": 0
+    }
+  },
+  "cyclomatic_complexity": {
+    "level": "ignore",
+    "value": 10
+  },
+  "duplicate_key": {
+    "level": "error"
+  },
+  "empty_constructor_needs_parens": {
+    "level": "ignore"
+  },
+  "ensure_comprehensions": {
+    "level": "warn"
+  },
+  "eol_last": {
+    "level": "ignore"
+  },
+  "indentation": {
+    "value": 2,
+    "level": "warn"
+  },
+  "line_endings": {
+    "level": "ignore",
+    "value": "unix"
+  },
+  "max_line_length": {
+    "value": 80,
+    "level": "ignore",
+    "limitComments": true
+  },
+  "missing_fat_arrows": {
+    "level": "ignore",
+    "is_strict": false
+  },
+  "newlines_after_classes": {
+    "value": 3,
+    "level": "ignore"
+  },
+  "no_backticks": {
+    "level": "error"
+  },
+  "no_debugger": {
+    "level": "warn",
+    "console": false
+  },
+  "no_empty_functions": {
+    "level": "ignore"
+  },
+  "no_empty_param_list": {
+    "level": "ignore"
+  },
+  "no_implicit_braces": {
+    "level": "ignore",
+    "strict": true
+  },
+  "no_implicit_parens": {
+    "level": "ignore",
+    "strict": true
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "ignore"
+  },
+  "no_nested_string_interpolation": {
+    "level": "warn"
+  },
+  "no_plusplus": {
+    "level": "ignore"
+  },
+  "no_private_function_fat_arrows": {
+    "level": "warn"
+  },
+  "no_stand_alone_at": {
+    "level": "ignore"
+  },
+  "no_tabs": {
+    "level": "error"
+  },
+  "no_this": {
+    "level": "ignore"
+  },
+  "no_throwing_strings": {
+    "level": "error"
+  },
+  "no_trailing_semicolons": {
+    "level": "error"
+  },
+  "no_trailing_whitespace": {
+    "level": "ignore",
+    "allowed_in_comments": false,
+    "allowed_in_empty_lines": true
+  },
+  "no_unnecessary_double_quotes": {
+    "level": "ignore"
+  },
+  "no_unnecessary_fat_arrows": {
+    "level": "warn"
+  },
+  "non_empty_constructor_needs_parens": {
+    "level": "ignore"
+  },
+  "prefer_english_operator": {
+    "level": "ignore",
+    "doubleNotLevel": "ignore"
+  },
+  "space_operators": {
+    "level": "ignore"
+  },
+  "spacing_after_comma": {
+    "level": "ignore"
+  },
+  "transform_messes_up_line_numbers": {
+    "level": "warn"
+  }
+}

--- a/.github/linters/.dockerfilelintrc
+++ b/.github/linters/.dockerfilelintrc
@@ -1,0 +1,104 @@
+---
+###########################
+###########################
+## Dockerfile Lint rules ##
+###########################
+###########################
+
+#################################
+# Default is 'on' for all rules #
+#  You can disable as needed.   #
+#################################
+# Additional Info can be found at:
+# https://github.com/replicatedhq/dockerfilelint
+
+# Set the rules
+rules:
+  # All commands in a Dockerfile require at least 1 argument
+  required_params: on
+
+  # For clarity and readability, all instructions in
+  # a Dockerfile should be uppercase
+  uppercase_commands: on
+
+  # The first instruction in a Dockerfile must specify
+  # the base image using a FROM
+  from_first: on
+
+  # This line is not a valid Dockerfile line
+  invalid_line: on
+
+  # Use of sudo is not allowed in a Dockerfile
+  sudo_usage: on
+
+  # Consider using a `--no-install-recommends` when `apt-get`
+  # installing packages
+  apt-get_missing_param: on
+
+  # Consider using a `--no-install-recommends` when `apt-get`
+  # installing packages
+  apt-get_recommends: on
+
+  # Use of `apt-get upgrade` is not allowed in a Dockerfile
+  apt-get-upgrade: on
+
+  # Use of `apt-get dist-upgrade` is not allowed in a Dockerfile
+  apt-get-dist-upgrade: on
+
+  # All instances of `apt-get update` should have the `apt-get install`
+  # commands on the same line to reduce image size
+  apt-get-update_require_install: on
+
+  # Consider using a `--no-cache` (supported in alpine linux >= 3.3) or
+  # `--update` followed by the command `rm -rf /var/cache/apk/*`
+  # when `apk` adding packages.  This will result in a smaller image size
+  apkadd-missing_nocache_or_updaterm: on
+
+  # Consider using a `--virtual` or `-t` switch to group multiple packages
+  # for easy cleanup.  This will help ensure future authors will continue
+  # to clean up build dependencies and other temporary packages
+  apkadd-missing-virtual: on
+
+  # Exposing ports should only be valid port numbers
+  invalid_port: on
+
+  # Only valid commands are allowed in a Dockerfile
+  invalid_command: on
+
+  # Expose Only Container Port
+  expose_host_port: on
+
+  # Using LABEL should be in key=value format
+  label_invalid: on
+
+  # Base images should specify a tag to use
+  missing_tag: on
+
+  # Base images should not use the latest tag
+  latest_tag: on
+
+  # This command has extra arguments and will be ignored
+  extra_args: on
+
+  # This command requires additional arguments
+  missing_args: on
+
+  # All files referenced in an ADD command should
+  # be part of the Docker build context
+  add_src_invalid: on
+
+  # When adding multiple files, the destination should be a directory
+  add_dest_invalid: on
+
+  # Using a WORKDIR parameter that has spaces should be escaped
+  invalid_workdir: on
+
+  # The arguments to this command are invalid
+  invalid_format: on
+
+  # Use of apt-get update should be paired with
+  # rm -rf /var/lib/apt/lists/* in the same layer
+  apt-get_missing_rm: on
+
+  # This INSTRUCTION is deprecated as of Docker 1.13
+  deprecated_in_1.13: on

--- a/.github/linters/.eslintrc.yml
+++ b/.github/linters/.eslintrc.yml
@@ -1,0 +1,65 @@
+---
+---
+#############################
+#############################
+## JavaScript Linter rules ##
+#############################
+#############################
+
+extends: eslint:recommended
+
+############
+# Env Vars #
+############
+env:
+  browser: true
+  es6: true
+
+###############
+# Global Vars #
+###############
+globals:
+  URLSearchParams: false
+  ga: false
+  skipWaiting: false
+  clients: false
+  PasswordCredential: false
+
+###############
+# Parser vars #
+###############
+parser: babel-eslint
+parserOptions:
+  sourceType: module
+  ecmaVersion: 2018
+
+###########
+# Plugins #
+###########
+plugins:
+  - async-await
+
+#########
+# Rules #
+#########
+rules:
+  indent:
+  - 2
+  - tab
+  quotes:
+  - 2
+  - single
+  semi:
+  - 2
+  - always
+  no-console: 0
+  async-await/space-after-async: 2
+  async-await/space-after-await: 2
+  generator-star-spacing:
+  - error
+  - before: false
+    after: true
+    anonymous: neither
+    method:
+      before: true
+      after: false

--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -1,0 +1,40 @@
+---
+#########################
+#########################
+## Golang Linter rules ##
+#########################
+#########################
+
+# configure golangci-lint
+# see https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+      - dupl
+      - gosec
+      - goconst
+linters:
+  enable:
+    - golint
+    - gosec
+    - unconvert
+    - gocyclo
+    - goconst
+    - goimports
+    - maligned
+    - gocritic
+linters-settings:
+  errcheck:
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    # default is false: such cases aren't reported by default.
+    check-blank: true
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+  gocyclo:
+    # minimal code complexity to report, 30 by default
+    min-complexity: 15
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,35 @@
+---
+###########################
+###########################
+## Markdown Linter rules ##
+###########################
+###########################
+
+# Linter rules doc:
+# - https://github.com/DavidAnson/markdownlint
+#
+# Note:
+# To comment out a single error:
+#   <!-- markdownlint-disable -->
+#   any violations you want
+#   <!-- markdownlint-restore -->
+#
+
+###############
+# Rules by id #
+###############
+MD004: false                  # Unordered list style
+MD007:
+  indent: 2                   # Unordered list indentation
+MD013:
+  line_length: 808            # Line length
+MD026:
+  punctuation: ".,;:!。，；:"  # List of not allowed
+MD029: false                  # Ordered list item prefix
+MD033: false                  # Allow inline HTML
+MD036: false                  # Emphasis used instead of a heading
+
+#################
+# Rules by tags #
+#################
+blank_lines: false  # Error on blank lines

--- a/.github/linters/.python-lint
+++ b/.github/linters/.python-lint
@@ -1,0 +1,542 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.github/linters/.ruby-lint.yml
+++ b/.github/linters/.ruby-lint.yml
@@ -1,0 +1,8 @@
+---
+#######################
+# Rubocop Config file #
+#######################
+
+inherit_gem:
+  rubocop-github:
+    - config/default.yml

--- a/.github/linters/.stylelintrc.json
+++ b/.github/linters/.stylelintrc.json
@@ -1,0 +1,19 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "block-no-empty": null,
+    "color-no-invalid-hex": true,
+    "comment-empty-line-before": [ "always", {
+      "ignore": ["stylelint-commands", "after-comment"]
+    } ],
+    "declaration-colon-space-after": "always",
+    "indentation": ["tab", {
+      "except": ["value"]
+    }],
+    "max-empty-lines": 2,
+    "rule-empty-line-before": [ "always", {
+      "except": ["first-nested"],
+      "ignore": ["after-comment"]
+    } ]
+  }
+}

--- a/.github/linters/.tflint.hcl
+++ b/.github/linters/.tflint.hcl
@@ -1,0 +1,32 @@
+// https://github.com/terraform-linters/tflint/blob/master/docs/guides/config.md
+config {
+  module = true
+  deep_check = false
+  force = false
+
+  // aws_credentials = {
+  //   access_key = "AWS_ACCESS_KEY"
+  //   secret_key = "AWS_SECRET_KEY"
+  //   region     = "us-east-1"
+  // }
+
+  // ignore_module = {
+  //   "github.com/terraform-linters/example-module" = true
+  // }
+
+  // varfile = ["example1.tfvars", "example2.tfvars"]
+
+  // variables = ["foo=bar", "bar=[\"baz\"]"]
+}
+
+rule "aws_instance_invalid_type" {
+  enabled = false
+}
+
+rule "aws_instance_previous_type" {
+  enabled = false
+}
+
+// plugin "example" {
+//   enabled = true
+// }

--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -1,0 +1,59 @@
+---
+###########################################
+# These are the rules used for            #
+# linting all the yaml files in the stack #
+# NOTE:                                   #
+# You can disble line with:               #
+# # yamllint disable-line                 #
+###########################################
+rules:
+  braces:
+    level: warning
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 1
+    max-spaces-inside-empty: 5
+  brackets:
+    level: warning
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 1
+    max-spaces-inside-empty: 5
+  colons:
+    level: warning
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    level: warning
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start:
+    level: warning
+    present: true
+  empty-lines:
+    level: warning
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    level: warning
+    max-spaces-after: 1
+  indentation:
+    level: warning
+    spaces: consistent
+    indent-sequences: true
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length:
+    level: warning
+    max: 80
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable

--- a/.github/linters/README.md
+++ b/.github/linters/README.md
@@ -1,0 +1,6 @@
+# TEMPLATES
+
+The files in this folder are template rules for the linters that will run against your code base. If you chose to copy these to your local repository in the directory: `.github/` they will be used at runtime. If they are not present, they will be used by default in the linter run.  
+
+The file(s) will be parsed at run time on the local branch to load all rules needed to run the **Super-Linter** **GitHub** Action.  
+The **GitHub** Action will inform the user via the **Checks API** on the status and success of the process.

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,77 @@
+---
+###########################
+###########################
+## Linter GitHub Actions ##
+###########################
+###########################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches:
+      - 'master'
+      - release/*
+  pull_request:
+    branches:
+      - master
+      - release/*
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v2.0.0
+        env:
+          # @TODO Add HTML when/if available
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: master
+          VALIDATE_YAML: true
+          VALIDATE_JSON: true
+          VALIDATE_XML: false
+          VALIDATE_MD: true
+          VALIDATE_BASH: true
+          VALIDATE_PERL: false
+          VALIDATE_PHP: false # PR currently open for PHP support, but including anyways
+          VALIDATE_PYTHON: false
+          VALIDATE_RUBY: false
+          VALIDATE_COFFEE: false
+          VALIDATE_ANSIBLE: false
+          VALIDATE_JAVASCRIPT_ES: false
+          VALIDATE_JAVASCRIPT_STANDARD: false
+          VALIDATE_TYPESCRIPT_ES: false
+          VALIDATE_TYPESCRIPT_STANDARD: false
+          VALIDATE_DOCKER: false
+          VALIDATE_GO: false
+          VALIDATE_TERRAFORM: false
+          VALIDATE_CSS: false
+          # ANSIBLE_DIRECTORY:
+          ACTIONS_RUNNER_DEBUG: false
+          # DEFAULT_WORKSPACE:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ News for the Kern River Valley
 ![GitHub forks](https://img.shields.io/github/forks/kernvalley/news.kernvalley.us.svg?style=social)
 ![GitHub stars](https://img.shields.io/github/stars/kernvalley/news.kernvalley.us.svg?style=social)
 ![Twitter Follow](https://img.shields.io/twitter/follow/kernvalley.svg?style=social)
-- - - 
+- - -
 
 - [Code of Conduct](./.github/CODE_OF_CONDUCT.md)
 - [Contributing](./.github/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # news.kernvalley.us
 News for the Kern River Valley
 
-[![Build Status](https://travis-ci.com/kernvalley/news.kernvalley.us.svg?branch=master)](https://travis-ci.com/kernvalley/news.kernvalley.us)
+[![Node CI](https://github.com/kernvalley/news.kernvalley.us/workflows/Node%20CI/badge.svg)](https://github.com/kernvalley/news.kernvalley.us/actions?query=workflow%3A%22Node+CI%22)
+[![Lint Code Base](https://github.com/kernvalley/news.kernvalley.us/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/kernvalley/news.kernvalley.us/actions?query=workflow%3A%22Lint+Code+Base%22)
 [![GitHub license](https://img.shields.io/github/license/kernvalley/news.kernvalley.us.svg)](https://github.com/kernvalley/news.kernvalley.us/blob/master/LICENSE)
 ![GitHub last commit](https://img.shields.io/github/last-commit/kernvalley/news.kernvalley.us.svg)
 ![GitHub release](https://img.shields.io/github/release/kernvalley/news.kernvalley.us.svg)
@@ -13,7 +14,7 @@ News for the Kern River Valley
 ![GitHub followers](https://img.shields.io/github/followers/kernvalley.svg?style=social)
 ![GitHub forks](https://img.shields.io/github/forks/kernvalley/news.kernvalley.us.svg?style=social)
 ![GitHub stars](https://img.shields.io/github/stars/kernvalley/news.kernvalley.us.svg?style=social)
-![Twitter Follow](https://img.shields.io/twitter/follow/kernvalley.svg?style=social)
+[![Twitter Follow](https://img.shields.io/twitter/follow/kern_valley.svg?style=social)](https://twitter.com/kern_valley)
 - - -
 
 - [Code of Conduct](./.github/CODE_OF_CONDUCT.md)

--- a/manifest.json.config
+++ b/manifest.json.config
@@ -1,5 +1,6 @@
 ---
 layout: null
+permalink: manifest.json
 ---
 {
 	"version": "{{ site.data.app.version | default: site.version }}",
@@ -15,5 +16,5 @@ layout: null
 	"screenshots": {{ site.data.app.screenshots | jsonify }},
 	"features": {{ site.data.app.features | jsonify }},
 	"related_applications":  {{ site.data.app.related_applications | jsonify }},
-  "categories": {{ site.data.app.categories | jsonify }}
+ 	"categories": {{ site.data.app.categories | jsonify }}
 }


### PR DESCRIPTION
Includes super linter config, individual linter config files, and updated templates, etc. Basically replaces all `/.github/` directory.

Resolves #16